### PR TITLE
Append remaining tracks from list when pressing play on a track.

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -422,12 +422,21 @@ impl App {
                             .for_each(|track| {
                                 self.queue.push(*track)
                             });
+                        if self.repeat == RepeatStatus::All {
+                            self.library.current_directory()
+                                .tracks[..index]
+                                .iter()
+                                .for_each(|track| {
+                                    self.queue.push(*track)
+                                });
+                        }
                     }
                     Viewing::Playlist(pl) => unsafe {
                         let id = pl.unwrap_unchecked();
-                        self.playlists.get_playlist(id)
-                            .unwrap_unchecked()
-                            .tracks[index..]
+                        let pl = self.playlists
+                            .get_playlist(id)
+                            .unwrap_unchecked();
+                        pl.tracks[index..]
                             .iter()
                             .map(|pt| match pt {
                                 PlaylistTrack::Unresolved(_) => None,
@@ -437,6 +446,18 @@ impl App {
                             .for_each(|track| {
                                 self.queue.push(track)
                             });
+                        if self.repeat == RepeatStatus::All {
+                            pl.tracks[..index]
+                                .iter()
+                                .map(|pt| match pt {
+                                    PlaylistTrack::Unresolved(_) => None,
+                                    PlaylistTrack::Track(id, _) => Some(*id)
+                                })
+                                .flatten()
+                                .for_each(|track| {
+                                    self.queue.push(track)
+                                });
+                        }
                     }
                 };
                 self.play_next();

--- a/src/app/view/tracks.rs
+++ b/src/app/view/tracks.rs
@@ -156,7 +156,7 @@ impl App {
         row![
             control_button!(
                 icon: Icon::Play,
-                msg: Message::PlayTrack(id),
+                msg: Message::PlayTrack(num),
                 style: style::plain_icon_button_with_colors(
                     iced::Color::parse("#242226").map(|c| c.into()),
                     None
@@ -193,7 +193,7 @@ impl App {
                 container(
                     column(vec![
                         button("Play")
-                            .on_press(Message::PlayTrack(id))
+                            .on_press(Message::PlayTrack(num))
                             .width(iced::Length::Fill)
                             .style(style::context_menu_button)
                             .into(),


### PR DESCRIPTION
When `RepeatStatus` is `One` or `None`, push all tracks in the current
folder or playlist after a selected track to the queue when pressing
"play" on that track, instead of the selected track only.

When `RepeatStatus` is `All`, also append the previous tracks before
the selected track to the queue.

Closes #3
