### PR TITLE
Isolate sidebar state.

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,5 @@
+use crate::internal::library::{directory_hash, path_hash};
+
 use super::*;
 use config::Config;
 use playlist::{Playlist, PlaylistMap, PlaylistTrack};
@@ -5,7 +7,7 @@ pub use view::ICON_FONT_BYTES;
 
 use iced::{task::Task, widget::combo_box};
 
-use view::start_screen;
+use view::{sidebar, start_screen};
 
 mod config;
 mod playlist;
@@ -24,8 +26,6 @@ pub enum Message {
     OpenImgDialog,
     OpenNewPlaylist,
     PinAdd(PinKind, PathBuf),
-    PinRemove(PinKind, usize),
-    PinSwap(PinKind, usize, usize),
     PlayFolder,
     PlayList,
     PlaylistPathChanged(String),
@@ -43,6 +43,7 @@ pub enum Message {
     Shuffle,
     ShuffleFolder,
     ShuffleList,
+    SidebarMessage(sidebar::SidebarMessage),
     SkipBack,
     SkipForward,
     StartScreen(start_screen::Message),
@@ -52,6 +53,7 @@ pub enum Message {
     ToggleRepeat,
     UpdateProgress,
     ViewLibrary(u64),
+    ViewLibraryRoot,
     ViewPlaylist(Option<u64>),
     VolumeChanged(f32),
 }
@@ -106,6 +108,7 @@ pub struct App {
     mute: bool,
     volume: f32,
     start_screen: Option<start_screen::StartScreen>,
+    sidebar: sidebar::Sidebar,
 
     selecting_playlist: Option<u64>,
 
@@ -170,6 +173,19 @@ impl App {
         let volume = config.misc.default_volume.min(1.0).max(0.0);
         sink.set_volume(volume);
 
+        let sidebar = sidebar::Sidebar::new(
+            config.library.pins.iter().map(|path| (
+                path_hash(&path),
+                path.file_stem().unwrap().to_str().unwrap().to_owned(),
+            ))
+                .collect(),
+            config.playlists.pins.iter().map(|path| {
+                let id = path_hash(&path);
+                (id, playlists.get_playlist(id).unwrap().title.to_owned())
+            })
+                .collect()
+        );
+
         Self {
             codec_registry: symphonia::default::get_codecs(),
             probe: symphonia::default::get_probe(),
@@ -187,6 +203,7 @@ impl App {
             track_duration: None,
             mute: false,
             volume,
+            sidebar,
             start_screen,
             selecting_playlist: None,
             new_playlist_menu: false,
@@ -311,39 +328,29 @@ impl App {
             Message::PinAdd(kind, path) => {
                 match kind {
                     PinKind::Library => {
-                        self.config.library.pins.push(path);
+                        self.config.library.pins.push(path.clone());
+                        Task::done(
+                            sidebar::SidebarMessage::LibraryAppend(
+                                path_hash(&path),
+                                path.file_stem().unwrap()
+                                    .to_str().unwrap().to_owned()
+                            )
+                                .into()
+                        )
                     }
                     PinKind::Playlist => {
-                        self.config.playlists.pins.push(path);
+                        self.config.playlists.pins.push(path.clone());
+                        let id = path_hash(&path);
+                        Task::done(
+                            sidebar::SidebarMessage::PlaylistAppend(
+                                path_hash(&path),
+                                self.playlists.get_playlist(id).unwrap()
+                                    .title.clone(),
+                            )
+                                .into()
+                        )
                     }
                 }
-                self.write_config()
-            }
-            Message::PinRemove(kind, index) => {
-                match kind {
-                    PinKind::Library => {
-                        self.config.library.pins.remove(index);
-                    }
-                    PinKind::Playlist => {
-                        self.config.playlists.pins.remove(index);
-                    }
-                }
-                self.write_config()
-            }
-            Message::PinSwap(kind, a, b) => {
-                match kind {
-                    PinKind::Library => {
-                        if b < self.config.library.pins.len() {
-                            self.config.library.pins.swap(a, b);
-                        }
-                    }
-                    PinKind::Playlist => {
-                        if b < self.config.playlists.pins.len() {
-                            self.config.playlists.pins.swap(a, b);
-                        }
-                    }
-                }
-                self.write_config()
             }
             Message::PlayFolder => {
                 let tracks = &self.library.current_directory().tracks;
@@ -553,6 +560,10 @@ impl App {
                 self.play_next();
                 Task::none()
             }
+            Message::SidebarMessage(msg) => {
+                self.sidebar.update(msg, &mut self.config);
+                self.write_config()
+            }
             Message::SkipBack => {
                 let Some(playing) = &self.playing else {
                     return Task::none();
@@ -651,6 +662,9 @@ impl App {
                 self.new_playlist_menu = false;
                 self.selecting_playlist = None;
                 Task::none()
+            }
+            Message::ViewLibraryRoot => {
+                Task::done(Message::ViewLibrary(self.library.root_dir))
             }
             Message::ViewPlaylist(val) => {
                 self.viewing = Viewing::Playlist(val);

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -13,7 +13,7 @@ mod controls;
 mod library;
 mod playlist;
 mod queue;
-mod sidebar;
+pub mod sidebar;
 pub mod start_screen;
 mod style;
 mod tracks;
@@ -133,7 +133,7 @@ impl App {
         container(
             column![
                 row![
-                    self.sidebar_view(),
+                    self.sidebar.view(),
                     iced::widget::vertical_space().width(5),
                     match self.viewing {
                         Viewing::Library => self.library_view(),

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -1,82 +1,103 @@
 use super::{ *, column };
 
-impl App {
-    pub(super) fn sidebar_view(&self) -> Element {
-        let library_btn = button(
-            row![
-                text!("{}", char::from(Icon::DiscAlbum))
-                    .font(ICON_FONT)
-                    .size(CONTROL_BUTTON_SIZE / 2)
-                    .align_y(iced::Alignment::Center),
-                text(" Library")
-                    .font(Font {
-                        weight: iced::font::Weight::Bold,
-                        ..Font::default()
-                    })
-                    .size(TEXT_SIZE)
-                    .align_y(iced::Alignment::Center),
-            ]
-                .height(iced::Length::Fill)
-                .align_y(iced::Alignment::Center),
-        )
-            .on_press(Message::ViewLibrary(self.library.root_dir))
-            .width(iced::Length::Fill)
-            .height(48)
-            .style(style::outlined_button)
-            .into();
+pub struct Sidebar {
+    library_pins: Vec<(u64, String)>,
+    playlist_pins: Vec<(u64, String)>,
+}
 
-        let playlists_btn = button(
-            row![
-                text!("{}", char::from(Icon::FileMusic))
-                    .font(ICON_FONT)
-                    .size(CONTROL_BUTTON_SIZE / 2)
-                    .align_y(iced::Alignment::Center),
-                text(" Playlists")
-                    .font(Font {
-                        weight: iced::font::Weight::Bold,
-                        ..Font::default()
-                    })
-                    .size(TEXT_SIZE)
-                    .align_y(iced::Alignment::Center),
-            ]
-                .height(iced::Length::Fill)
-                .align_y(iced::Alignment::Center),
-        )
-            .on_press(Message::ViewPlaylist(None))
-            .width(iced::Length::Fill)
-            .height(48)
-            .style(style::outlined_button)
-            .into();
+#[derive(Clone, Debug)]
+pub enum SidebarMessage {
+    LibraryAppend(u64, String),
+    LibraryRemove(usize),
+    LibrarySwap(usize, usize),
+    PlaylistAppend(u64, String),
+    PlaylistRemove(usize),
+    PlaylistSwap(usize, usize),
+}
 
+impl Into<Message> for SidebarMessage {
+    fn into(self) -> Message {
+        Message::SidebarMessage(self)
+    }
+}
+
+impl Sidebar {
+    pub fn new(
+        library_pins: Vec<(u64, String)>,
+        playlist_pins: Vec<(u64, String)>,
+    ) -> Self {
+        Self { library_pins, playlist_pins }
+    }
+
+    pub fn update(&mut self, msg: SidebarMessage, config: &mut Config) {
+        match msg {
+            SidebarMessage::LibraryAppend(id, name) => {
+                self.library_pins.push((id, name));
+            }
+            SidebarMessage::LibraryRemove(i) => {
+                config.library.pins.remove(i);
+                self.library_pins.remove(i);
+            }
+            SidebarMessage::LibrarySwap(i, j) => unsafe {
+                if j < self.library_pins.len() {
+                    config.library.pins.swap_unchecked(i, j);
+                    self.library_pins.swap_unchecked(i, j);
+                }
+            }
+            SidebarMessage::PlaylistAppend(id, name) => {
+                self.playlist_pins.push((id, name));
+            }
+            SidebarMessage::PlaylistRemove(i) => {
+                config.library.pins.remove(i);
+                self.playlist_pins.remove(i);
+            }
+            SidebarMessage::PlaylistSwap(i, j) => unsafe {
+                if j < self.playlist_pins.len() {
+                    config.library.pins.swap_unchecked(i, j);
+                    self.playlist_pins.swap_unchecked(i, j);
+                }
+            }
+        }
+    }
+
+    pub fn view(&self) -> Element {
         let mut contents = vec![];
-        contents.push(library_btn);
-        self.config.library.pins
-            .iter()
+        contents.push(
+            Self::section_btn(
+                Icon::DiscAlbum,
+                " Library",
+                Message::ViewLibraryRoot
+            )
+        );
+        self.library_pins.iter()
             .enumerate()
-            .for_each(|(i, dir)| {
-                let name = dir.file_name().unwrap().to_str().unwrap().to_owned();
-                contents.push(Self::sidebar_item_view(
-                    name,
-                    Message::ViewLibrary(crate::internal::library::path_hash(dir)),
-                    PinKind::Library,
-                    i,
+            .for_each(|(i, pin)| {
+                contents.push(Self::item_btn(
+                    &pin.1,
+                    Message::ViewLibrary(pin.0),
+                    SidebarMessage::LibrarySwap(i, i.saturating_sub(1)).into(),
+                    SidebarMessage::LibrarySwap(i, i.saturating_add(1)).into(),
+                    SidebarMessage::LibraryRemove(i).into(),
                 ));
             });
-        contents.push(playlists_btn);
-        self.config.playlists.pins
-            .iter()
+        contents.push(
+            Self::section_btn(
+                Icon::FileMusic,
+                " Playlists",
+                Message::ViewPlaylist(None)
+            )
+        );
+        self.playlist_pins.iter()
             .enumerate()
-            .for_each(|(i, pl)| {
-                let id = crate::internal::library::path_hash(pl);
-                let pl = self.playlists.get_playlist(id).unwrap();
-                contents.push(Self::sidebar_item_view(
-                    pl.title.clone(),
-                    Message::ViewPlaylist(Some(id)),
-                    PinKind::Playlist,
-                    i,
+            .for_each(|(i, pin)| {
+                contents.push(Self::item_btn(
+                    &pin.1,
+                    Message::ViewPlaylist(Some(pin.0)),
+                    SidebarMessage::PlaylistSwap(i, i.saturating_sub(1)).into(),
+                    SidebarMessage::PlaylistSwap(i, i.saturating_add(1)).into(),
+                    SidebarMessage::PlaylistRemove(i).into(),
                 ));
             });
-
         container(
             scrollable(
                 column(contents)
@@ -100,12 +121,42 @@ impl App {
             .into()
     }
 
-    fn sidebar_item_view(
-        txt: String,
-        msg: Message,
-        pin_kind: PinKind,
-        num: usize
+    fn section_btn(
+        icon: Icon,
+        txt: &'static str,
+        msg: Message
     ) -> Element<'static> {
+        button(
+            row![
+                text!("{}", char::from(icon))
+                    .font(ICON_FONT)
+                    .size(CONTROL_BUTTON_SIZE)
+                    .align_y(iced::Alignment::Center),
+                text(txt)
+                    .font(Font {
+                        weight: iced::font::Weight::Bold,
+                        ..Font::default()
+                    })
+                    .size(TEXT_SIZE)
+                    .align_y(iced::Alignment::Center),
+            ]
+                .height(iced::Length::Fill)
+                .align_y(iced::Alignment::Center),
+        )
+            .on_press(msg)
+            .width(iced::Length::Fill)
+            .height(48)
+            .style(style::outlined_button)
+            .into()
+    }
+
+    fn item_btn(
+        txt: &str,
+        open_msg: Message,
+        up_msg: Message,
+        down_msg: Message,
+        remove_msg: Message,
+    ) -> Element {
         iced::widget::hover(
             container(
                 button(
@@ -128,7 +179,7 @@ impl App {
                     })
                     .width(iced::Length::Fill)
                     .height(iced::Length::Fill)
-                    .on_press(msg)
+                    .on_press(open_msg)
             )
                 .width(iced::Length::Fill)
                 .height(42),
@@ -136,22 +187,14 @@ impl App {
                 row![
                     column![
                         icon_button(Icon::ChevronUp, 12)
-                            .on_press(Message::PinSwap(
-                                pin_kind,
-                                num,
-                                num.saturating_sub(1)
-                            ))
+                            .on_press(up_msg)
                             .padding(1)
                             .style(style::plain_icon_button_with_colors(
                                 iced::Color::parse("#242226").map(|c| c.into()),
                                 None
                             )),
                         icon_button(Icon::ChevronDown, 12)
-                            .on_press(Message::PinSwap(
-                                pin_kind,
-                                num,
-                                num.saturating_add(1)
-                            ))
+                            .on_press(down_msg)
                             .padding(1)
                             .style(style::plain_icon_button_with_colors(
                                 iced::Color::parse("#242226").map(|c| c.into()),
@@ -160,7 +203,7 @@ impl App {
                     ],
                     control_button!(
                         icon: Icon::PinOff,
-                        msg: Message::PinRemove(pin_kind, num),
+                        msg: remove_msg,
                         style: style::plain_icon_button,
                     )
                 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![feature(new_range_api)]
 #![feature(seek_stream_len)]
 #![feature(slice_as_array)]
+#![feature(slice_swap_unchecked)]
 
 use app::App;
 use iced::advanced::graphics::image::image_rs::ImageFormat;


### PR DESCRIPTION
Beyond reducing clutter in the main `App` struct, while it does
create a separate version of the pins lists to ensure stays
identical to the other, it also makes the conversion from a list
of paths (as the config lists pins) to a list of hash IDs and
names only happen once rather than on every render frame.
