### PR TITLE
Apply several lints.

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -83,15 +83,9 @@ impl Default for Library {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Default, Deserialize, Serialize)]
 pub struct Playlists {
     pub pins: Vec<PathBuf>,
-}
-
-impl Default for Playlists {
-    fn default() -> Self {
-        Self { pins: vec![] }
-    }
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -391,7 +391,7 @@ impl App {
                 Task::none()
             }
             Message::PlayNext => {
-                if self.queue.len() == 0 {
+                if self.queue.is_empty() {
                     return Task::none();
                 }
                 let track = self.queue.remove(0);
@@ -526,7 +526,7 @@ impl App {
                 }
             }
             self.playing = None;
-            if self.queue.len() != 0 {
+            if !self.queue.is_empty() {
                 Task::done(Message::PlayNext)
             } else {
                 self.playhead_position = 0.0;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -438,12 +438,10 @@ impl App {
             }
             Message::StartScreen(msg) => {
                 if let Some(start) = &mut self.start_screen {
-                    if let Some(_) = &start.lib {
+                    if start.lib.is_some() {
                         Task::done(Message::ScanDone)
                     } else {
-                        start
-                            .update(msg)
-                            .map(|s_msg| Message::StartScreen(s_msg))
+                        start.update(msg).map(Message::StartScreen)
                     }
                 } else {
                     Task::none()
@@ -501,7 +499,7 @@ impl App {
                 self.viewing = Viewing::Playlist(val);
                 self.new_playlist_menu = false;
                 self.selecting_playlist = None;
-                if let Some(_) = val {
+                if val.is_some() {
                     scrollable::scroll_to(
                         scrollable::Id::new("playlist"),
                         scrollable::AbsoluteOffset { x: 0.0, y: 0.0 },

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -163,7 +163,7 @@ impl App {
         );
 
         let sink = rodio::Sink::try_new(&stream_handle).unwrap();
-        let volume = config.misc.default_volume.min(1.0).max(0.0);
+        let volume = config.misc.default_volume.clamp(0.0, 1.0);
         sink.set_volume(volume);
 
         let sidebar = sidebar::Sidebar::new(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -169,7 +169,7 @@ impl App {
                 .iter()
                 .map(|path| {
                     (
-                        path_hash(&path),
+                        path_hash(path),
                         path.file_stem().unwrap().to_str().unwrap().to_owned(),
                     )
                 })
@@ -179,7 +179,7 @@ impl App {
                 .pins
                 .iter()
                 .map(|path| {
-                    let id = path_hash(&path);
+                    let id = path_hash(path);
                     (id, playlists.get_playlist(id).unwrap().title.to_owned())
                 })
                 .collect(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 use config::Config;
-use iced::{task::Task, widget::combo_box};
+use iced::task::Task;
 use playlist::{Playlist, PlaylistMap, PlaylistTrack};
 pub use view::ICON_FONT_BYTES;
 use view::{queue, sidebar, start_screen};
@@ -157,10 +157,6 @@ impl App {
 
         let mut playlists = PlaylistMap::new();
         playlists.scan_playlists();
-
-        let add_to_playlist_state = combo_box::State::new(
-            playlists.playlists().map(|(id, _)| *id).collect(),
-        );
 
         let sink = rodio::Sink::try_new(&stream_handle).unwrap();
         let volume = config.misc.default_volume.clamp(0.0, 1.0);

--- a/src/app/playlist.rs
+++ b/src/app/playlist.rs
@@ -112,7 +112,7 @@ impl Playlist {
 
     pub fn from_toml(toml: TomlPlaylist, filename: String) -> Self {
         let title = toml.title;
-        let img = toml.img.map(|s| PathBuf::from(s));
+        let img = toml.img.map(PathBuf::from);
         let mut tracks = Vec::with_capacity(toml.tracks.capacity());
         for track in toml.tracks {
             let track = PathBuf::from(track);

--- a/src/app/playlist.rs
+++ b/src/app/playlist.rs
@@ -47,7 +47,7 @@ impl PlaylistMap {
         if !path.exists() {
             return Ok(());
         }
-        for entry in path.read_dir().unwrap().into_iter() {
+        for entry in path.read_dir().unwrap() {
             if let Err(e) = entry {
                 eprintln!("Error reading entry: {e}");
             } else if let Ok(entry) = entry {

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -129,7 +129,7 @@ pub(self) use fill;
 impl App {
     pub fn view(&self) -> Element {
         if let Some(start) = &self.start_screen {
-            start.view().map(|s_msg| Message::StartScreen(s_msg))
+            start.view().map(Message::StartScreen)
         } else {
             self.main_screen()
         }

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -169,7 +169,7 @@ fn print_artists(artists: &Vec<String>) -> String {
     let mut txt = String::new();
 
     for artist in artists {
-        txt.push_str(&format!("{}, ", artist));
+        txt.push_str(&format!("{artist}, "));
     }
 
     txt.pop();
@@ -184,8 +184,8 @@ fn print_duration(duration: &std::time::Duration) -> String {
     if mins >= 100 {
         let hrs = mins / 60;
         let mins = mins % 60;
-        format!("{}:{:#02}:{:#02}", hrs, mins, secs)
+        format!("{hrs}:{mins:#02}:{secs:#02}")
     } else {
-        format!("{:#02}:{:#02}", mins, secs)
+        format!("{mins:#02}:{secs:#02}")
     }
 }

--- a/src/app/view/playlist.rs
+++ b/src/app/view/playlist.rs
@@ -285,10 +285,7 @@ impl App {
             .iter()
             .map(|t| match t {
                 PlaylistTrack::Track(id, _) => {
-                    match self.library.get_track(*id) {
-                        Some(track) => Some((*id, track)),
-                        None => None,
-                    }
+                    self.library.get_track(*id).map(|track| (*id, track))
                 }
                 PlaylistTrack::Unresolved(_) => None,
             })

--- a/src/app/view/playlist.rs
+++ b/src/app/view/playlist.rs
@@ -283,13 +283,12 @@ impl App {
         let mut contents = pl
             .tracks
             .iter()
-            .map(|t| match t {
+            .filter_map(|t| match t {
                 PlaylistTrack::Track(id, _) => {
                     self.library.get_track(*id).map(|track| (*id, track))
                 }
                 PlaylistTrack::Unresolved(_) => None,
             })
-            .flatten()
             .enumerate()
             .map(|(num, (id, track))| {
                 Self::track_view(track, id, num + 1, true)

--- a/src/app/view/queue.rs
+++ b/src/app/view/queue.rs
@@ -127,11 +127,10 @@ impl App {
                 .unwrap()
                 .tracks
                 .iter()
-                .map(|track| match track {
+                .filter_map(|track| match track {
                     PlaylistTrack::Track(id, _) => Some(*id),
                     _ => None,
                 })
-                .flatten()
                 .collect::<Vec<_>>()
         }
 
@@ -185,20 +184,18 @@ impl App {
                             self.playlists.get_playlist(id).unwrap_unchecked();
                         pl.tracks[i..]
                             .iter()
-                            .map(|pt| match pt {
+                            .filter_map(|pt| match pt {
                                 PlaylistTrack::Unresolved(_) => None,
                                 PlaylistTrack::Track(id, _) => Some(*id),
                             })
-                            .flatten()
                             .for_each(|track| self.queue.push(track));
                         if self.repeat == RepeatStatus::All {
                             pl.tracks[..i]
                                 .iter()
-                                .map(|pt| match pt {
+                                .filter_map(|pt| match pt {
                                     PlaylistTrack::Unresolved(_) => None,
                                     PlaylistTrack::Track(id, _) => Some(*id),
                                 })
-                                .flatten()
                                 .for_each(|track| self.queue.push(track));
                         }
                     },

--- a/src/app/view/queue.rs
+++ b/src/app/view/queue.rs
@@ -153,14 +153,14 @@ impl App {
             QueueMessage::PlayFolder => {
                 let tracks = &self.library.current_directory().tracks;
                 self.queue.resize(tracks.len(), 0);
-                self.queue.copy_from_slice(&tracks);
+                self.queue.copy_from_slice(tracks);
                 Task::done(Message::PlayNext)
             }
             QueueMessage::PlayList => {
                 let Viewing::Playlist(Some(list)) = self.viewing else {
                     return Task::none();
                 };
-                let tracks = get_tracks_from_playlist(&self, list);
+                let tracks = get_tracks_from_playlist(self, list);
                 self.queue.resize(tracks.len(), 0);
                 self.queue.copy_from_slice(&tracks);
                 Task::done(Message::PlayNext)
@@ -221,7 +221,7 @@ impl App {
                 let Viewing::Playlist(Some(list)) = self.viewing else {
                     return Task::none();
                 };
-                let tracks = get_tracks_from_playlist(&self, list);
+                let tracks = get_tracks_from_playlist(self, list);
                 shuffle_into_queue(&mut self.queue, &tracks);
                 Task::done(Message::PlayNext)
             }

--- a/src/app/view/queue.rs
+++ b/src/app/view/queue.rs
@@ -258,11 +258,8 @@ impl App {
                 let Some(playing) = &self.playing else {
                     return Task::none();
                 };
-                match self.repeat {
-                    RepeatStatus::All => {
-                        self.queue.push(track_hash(playing));
-                    }
-                    _ => (),
+                if self.repeat == RepeatStatus::All {
+                    self.queue.push(track_hash(playing));
                 }
                 Task::done(Message::PlayNext)
             }

--- a/src/app/view/start_screen.rs
+++ b/src/app/view/start_screen.rs
@@ -59,7 +59,7 @@ impl StartScreen {
                     }
                     Err(e) => {
                         eprintln!("Error verifying existence of path: {e}");
-                        return Task::done(Message::Error);
+                        Task::done(Message::Error)
                     }
                 }
             }

--- a/src/app/view/style.rs
+++ b/src/app/view/style.rs
@@ -96,13 +96,13 @@ pub(super) fn plain_icon_button(
         text_color: match status {
             button::Status::Hovered => iced::Color {
                 a: 0.60,
-                ..palette.background.base.text.into()
+                ..palette.background.base.text
             },
             button::Status::Pressed => iced::Color {
                 a: 0.40,
-                ..palette.background.base.text.into()
+                ..palette.background.base.text
             },
-            _ => palette.background.base.text.into(),
+            _ => palette.background.base.text,
         },
         background: Some(palette.background.base.color.into()),
         ..button::Style::default()
@@ -143,7 +143,7 @@ pub(super) fn play_button(
             .into(),
             _ => palette.background.base.text.into(),
         }),
-        text_color: palette.background.base.color.into(),
+        text_color: palette.background.base.color,
         border: iced::Border::rounded(
             iced::Border::default(),
             CONTROL_BUTTON_SIZE / 2,

--- a/src/internal/audio/output.rs
+++ b/src/internal/audio/output.rs
@@ -313,10 +313,8 @@ impl<S: ConvertibleSample> SymphoniaDecoder<S> {
             let packet_len = sample_buf.len();
             match self.wait_for_vacancy(packet_len).await {
                 Ok(_) => {
-                    let mut samples = sample_buf
-                        .samples()
-                        .iter()
-                        .map(|s| (self.convert)(*s));
+                    let mut samples =
+                        sample_buf.samples().iter().map(|s| (self.convert)(*s));
                     let written =
                         self.ring_buf_writer.push_iter(samples.by_ref());
                     debug_assert_eq!(written, packet_len);

--- a/src/internal/audio/output.rs
+++ b/src/internal/audio/output.rs
@@ -214,7 +214,7 @@ impl Iterator for AudioStream {
         }
         let res = self.ring_buf_reader.try_pop();
         if res.is_none() {
-            (!self.handle.is_finished()).then(|| 0_f32)
+            (!self.handle.is_finished()).then_some(0_f32)
         } else {
             res
         }

--- a/src/internal/audio/output.rs
+++ b/src/internal/audio/output.rs
@@ -303,7 +303,7 @@ impl<S: ConvertibleSample> SymphoniaDecoder<S> {
                         None
                     }
                 })
-                .last()
+                .next_back()
                 .inspect(|target| {
                     self.seek(*target);
                 });
@@ -315,7 +315,7 @@ impl<S: ConvertibleSample> SymphoniaDecoder<S> {
                 Ok(_) => {
                     let mut samples = sample_buf
                         .samples()
-                        .into_iter()
+                        .iter()
                         .map(|s| (self.convert)(*s));
                     let written =
                         self.ring_buf_writer.push_iter(samples.by_ref());

--- a/src/internal/library.rs
+++ b/src/internal/library.rs
@@ -10,7 +10,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use super::{Directory, Track};
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Library {
     pub root_dir: u64,
     pub curr_dir: u64,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -48,7 +48,7 @@ pub struct Track {
     pub metadata: Metadata,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Metadata {
     pub title: Option<String>,
     pub artists: Vec<String>,
@@ -56,17 +56,4 @@ pub struct Metadata {
     pub discnum: Option<usize>,
     pub num: Option<usize>,
     pub duration: Option<Duration>,
-}
-
-impl Default for Metadata {
-    fn default() -> Self {
-        Self {
-            title: None,
-            artists: vec![],
-            album: None,
-            discnum: None,
-            num: None,
-            duration: None,
-        }
-    }
 }

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -22,9 +22,7 @@ pub fn partial_scan(path: &Path, mut lib: Library) -> Library {
 }
 
 fn scan_file(path: &PathBuf) -> Option<ScanResult> {
-    let Some(extension) = path.extension() else {
-        return None;
-    };
+    let extension = path.extension()?;
     let extension = extension.to_str().unwrap();
     match extension {
         "flac" => Some(ScanResult::Track(scan_flac(path))),

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::*;
 
 enum ScanResult {
@@ -5,16 +7,17 @@ enum ScanResult {
     Image(PathBuf),
 }
 
-pub fn scan(path: &PathBuf) -> Library {
+pub fn scan(path: &Path) -> Library {
     let mut lib = Library::new();
-    let root = scan_dir(&mut lib, path.clone())
-        .unwrap_or_else(|| lib.add_directory(Directory::new(path.clone())));
+    let root = scan_dir(&mut lib, path.to_path_buf()).unwrap_or_else(|| {
+        lib.add_directory(Directory::new(path.to_path_buf()))
+    });
     lib.set_root(root);
     lib
 }
 
-pub fn partial_scan(path: &PathBuf, mut lib: Library) -> Library {
-    scan_dir(&mut lib, path.clone());
+pub fn partial_scan(path: &Path, mut lib: Library) -> Library {
+    scan_dir(&mut lib, path.to_path_buf());
     lib
 }
 
@@ -373,7 +376,7 @@ fn scan_dir(lib: &mut Library, path_buf: PathBuf) -> Option<u64> {
     }
 }
 
-fn sort_tracks(tracks: &mut Vec<Track>, stable: bool) {
+fn sort_tracks(tracks: &mut [Track], stable: bool) {
     let sort = |track: &Track| {
         let path = track.path.to_str().unwrap().to_owned();
         (
@@ -395,7 +398,7 @@ fn sort_tracks(tracks: &mut Vec<Track>, stable: bool) {
     }
 }
 
-fn sort_images(imgs: Vec<PathBuf>, dir_path: &PathBuf) -> Option<PathBuf> {
+fn sort_images(imgs: Vec<PathBuf>, dir_path: &Path) -> Option<PathBuf> {
     if !imgs.is_empty() && imgs.len() != 1 {
         let mut first_alphabetical: Option<&PathBuf> = None;
         let mut matches_dir_name = None;

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -318,7 +318,7 @@ fn scan_dir(lib: &mut Library, path_buf: PathBuf) -> Option<u64> {
     let mut tracks_temp = vec![];
     let mut imgs_temp = vec![];
 
-    for entry in path.read_dir().unwrap().into_iter() {
+    for entry in path.read_dir().unwrap() {
         if let Err(_e) = entry {
             todo!()
         } else if let Ok(entry) = entry {

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -74,8 +74,7 @@ fn scan_flac(path: &PathBuf) -> Track {
 }
 
 fn scan_mp3(path: &PathBuf) -> Track {
-    let metadata =
-        read_id3(path).unwrap_or(read_ape(path).unwrap_or_default());
+    let metadata = read_id3(path).unwrap_or(read_ape(path).unwrap_or_default());
 
     let duration = mp3_duration::from_read(&mut File::open(path).unwrap()).ok();
     let metadata = Metadata {
@@ -194,11 +193,16 @@ fn get_vorbis_duration(path: &PathBuf) -> Option<u32> {
             let mut lo = [0; 4];
             f.read_exact(&mut lo).ok()?;
             f.read_exact(&mut hi).ok()?;
-            if matches!([&lo, &hi], [&[0xFF, 0xFF, 0xFF, 0xFF], &[
-                0xFF, 0xFF, 0xFF, 0xFF
-            ]]) {
+
+            // rustfmt makes this match macro very ugly if allowed to:
+            #[rustfmt::skip]
+            if matches!(
+                [&lo, &hi],
+                [&[0xFF, 0xFF, 0xFF, 0xFF], &[0xFF, 0xFF, 0xFF, 0xFF]]
+            ) {
                 return None;
             }
+
             if hi != [0; 4] {
                 lo = [0xFF, 0xFF, 0xFF, 0xFE];
             }

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -351,7 +351,7 @@ fn scan_dir(lib: &mut Library, path_buf: PathBuf) -> Option<u64> {
         }
     }
 
-    if tracks_temp.len() != 0 {
+    if !tracks_temp.is_empty() {
         dir.tracks
             .iter()
             .map(|t| unsafe { lib.get_track(*t).unwrap_unchecked() })

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -26,7 +26,7 @@ fn scan_file(path: &PathBuf) -> Option<ScanResult> {
     match extension {
         "flac" => Some(ScanResult::Track(scan_flac(path))),
         "mp3" => Some(ScanResult::Track(scan_mp3(path))),
-        "ogg" => scan_vorbis(path).map(|v| ScanResult::Track(v)),
+        "ogg" => scan_vorbis(path).map(ScanResult::Track),
         "wav" | "wave" => Some(ScanResult::Track(scan_wav(path))),
         "jpg" | "jpeg" | "png" => Some(ScanResult::Image(path.to_owned())),
         _ => None,

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -47,11 +47,11 @@ fn scan_flac(path: &PathBuf) -> Track {
     let discnum = reader
         .get_tag("DISCNUMBER")
         .next()
-        .map(|s| s.split('/').nth(0).unwrap().parse::<usize>().unwrap_or(0));
+        .map(|s| s.split('/').next().unwrap().parse::<usize>().unwrap_or(0));
     let num = reader
         .get_tag("TRACKNUMBER")
         .next()
-        .map(|s| s.split('/').nth(0).unwrap().parse::<usize>().unwrap_or(0));
+        .map(|s| s.split('/').next().unwrap().parse::<usize>().unwrap_or(0));
     let duration = {
         let stream_info = reader.streaminfo();
         Duration::from_secs(
@@ -75,7 +75,7 @@ fn scan_flac(path: &PathBuf) -> Track {
 
 fn scan_mp3(path: &PathBuf) -> Track {
     let metadata =
-        read_id3(path).unwrap_or(read_ape(path).unwrap_or(Metadata::default()));
+        read_id3(path).unwrap_or(read_ape(path).unwrap_or_default());
 
     let duration = mp3_duration::from_read(&mut File::open(path).unwrap()).ok();
     let metadata = Metadata {
@@ -124,7 +124,7 @@ fn scan_vorbis(path: &PathBuf) -> Option<Track> {
                 discnum = Some(
                     value
                         .split('/')
-                        .nth(0)
+                        .next()
                         .unwrap()
                         .parse::<usize>()
                         .unwrap_or(0),
@@ -134,7 +134,7 @@ fn scan_vorbis(path: &PathBuf) -> Option<Track> {
                 num = Some(
                     value
                         .split('/')
-                        .nth(0)
+                        .next()
                         .unwrap()
                         .parse::<usize>()
                         .unwrap_or(0),
@@ -210,7 +210,7 @@ fn get_vorbis_duration(path: &PathBuf) -> Option<u32> {
 }
 
 fn scan_wav(path: &PathBuf) -> Track {
-    let mut metadata = read_id3(path).unwrap_or(Metadata::default());
+    let mut metadata = read_id3(path).unwrap_or_default();
 
     if metadata.duration.is_none() {
         let reader = hound::WavReader::open(path).unwrap();
@@ -283,7 +283,7 @@ fn read_ape(path: &PathBuf) -> Option<Metadata> {
                 <ape::Item as TryInto<String>>::try_into(i.to_owned())
                     .unwrap()
                     .split('/')
-                    .nth(0)
+                    .next()
                     .unwrap()
                     .parse::<usize>()
                     .unwrap_or(0)
@@ -443,7 +443,7 @@ fn sort_images(imgs: Vec<PathBuf>, dir_path: &PathBuf) -> Option<PathBuf> {
             unsafe { first_alphabetical.unwrap_unchecked().to_owned() }
         })
     } else {
-        imgs.get(0).cloned()
+        imgs.first().cloned()
     }
 }
 

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -167,11 +167,7 @@ fn scan_vorbis(path: &PathBuf) -> Option<Track> {
 fn get_vorbis_duration(path: &PathBuf) -> Option<u32> {
     let mut f = File::open(path).ok()?;
     let init_len = f.stream_len().ok()?;
-    let offset = if init_len > 65536 {
-        init_len - 65536
-    } else {
-        0
-    };
+    let offset = init_len.saturating_sub(65536);
     f.seek(std::io::SeekFrom::Start(offset)).ok()?;
     let mut buf = [0; 5];
     loop {

--- a/src/internal/scan.rs
+++ b/src/internal/scan.rs
@@ -322,33 +322,30 @@ fn scan_dir(lib: &mut Library, path_buf: PathBuf) -> Option<u64> {
         if let Err(_e) = entry {
             todo!()
         } else if let Ok(entry) = entry {
-            match entry.file_type() {
-                Ok(ft) => {
-                    if ft.is_dir() {
-                        scan_dir(lib, entry.path()).inspect(|id| {
-                            if !dir.subdirs.contains(id) {
-                                dir.subdirs.push(*id)
-                            }
-                        });
-                    } else {
-                        if lib
-                            .get_track(library::path_hash(&entry.path()))
-                            .is_some()
-                        {
-                            continue;
+            if let Ok(ft) = entry.file_type() {
+                if ft.is_dir() {
+                    scan_dir(lib, entry.path()).inspect(|id| {
+                        if !dir.subdirs.contains(id) {
+                            dir.subdirs.push(*id)
                         }
-                        match scan_file(&entry.path()) {
-                            Some(ScanResult::Image(data)) => {
-                                imgs_temp.push(data);
-                            }
-                            Some(ScanResult::Track(track)) => {
-                                tracks_temp.push(track);
-                            }
-                            None => (),
+                    });
+                } else {
+                    if lib
+                        .get_track(library::path_hash(&entry.path()))
+                        .is_some()
+                    {
+                        continue;
+                    }
+                    match scan_file(&entry.path()) {
+                        Some(ScanResult::Image(data)) => {
+                            imgs_temp.push(data);
                         }
+                        Some(ScanResult::Track(track)) => {
+                            tracks_temp.push(track);
+                        }
+                        None => (),
                     }
                 }
-                Err(_) => (),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(seek_stream_len)]
 #![feature(slice_as_array)]
 #![feature(slice_swap_unchecked)]
+#![feature(stmt_expr_attributes)]
 #![deny(unused_imports)]
 #![deny(unused_import_braces)]
 


### PR DESCRIPTION
* Derive `Default` for `Metadata` instead of manual impl.
* Derive `Default` for `Library`.
* Derive `Default` for `config::Playlists` instead of manual impl.
* Remove unnecessary conversions to same type.
* Remove unnecessary match statements.
* Remove `.map(...).flatten()` patterns.
* Remove manual arithmetic check.
* Remove unnecessary closures and pattern matching.
* Use variables directly in `format!` string.
* Use `clamp` for volume instead of `.min(...).max(...)`.
* Use more idiomatic methods for iterators.
* Fix a formatting issue.
* Remove deprecated `add_to_playlist_state` variable.
* Remove redundant references.
* Use slice types rather than types involving new objects.
* Use `?` operator instead of `if let`.
* Remove unnecessary `return`.
- **Replace `.len() == 0` with `.is_empty()`.**
